### PR TITLE
fix(docs): drop ?file= from StackBlitz links

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ shipped with the box:
 
 ## Playground
 
-➔ **[Open in StackBlitz](https://stackblitz.com/github/lacymorrow/react-github-readme-md/tree/main/examples/stackblitz?file=src/main.tsx)** — a tiny Vite + React + TS app with editable `username` / `repo` inputs that re-renders the chosen README live.
+➔ **[Open in StackBlitz](https://stackblitz.com/github/lacymorrow/react-github-readme-md/tree/main/examples/stackblitz)** — a tiny Vite + React + TS app with editable `username` / `repo` inputs that re-renders the chosen README live.
 
 Local copy: [`examples/stackblitz/`](./examples/stackblitz)
 

--- a/examples/stackblitz/README.md
+++ b/examples/stackblitz/README.md
@@ -4,7 +4,7 @@ A minimal Vite + React + TypeScript app that renders any GitHub repo's README in
 
 ## Open it live
 
-➔ **[Open in StackBlitz](https://stackblitz.com/github/lacymorrow/react-github-readme-md/tree/main/examples/stackblitz?file=src/main.tsx)**
+➔ **[Open in StackBlitz](https://stackblitz.com/github/lacymorrow/react-github-readme-md/tree/main/examples/stackblitz)**
 
 ## Run locally
 


### PR DESCRIPTION
## Summary

- The `?file=src/main.tsx` query parameter triggers a noisy `Could not find source file: 'stackblitz:/src/main.tsx'` warning in StackBlitz's editor.
- Vite itself starts fine — the param only affects the editor's file-focus behavior — but the warning is repeated and shows up as a console error. Cleaner to omit it.

## Test plan
- [x] StackBlitz demo opens cleanly with no "Could not find source file" warnings