### PR TITLE
ci: upgrade github/codeql-action v3→v4 and checkout v4→v6 (Node.js 24)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,18 +23,18 @@ jobs:
         language: ['javascript-typescript']
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           queries: security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary

Upgrades CodeQL workflow to Node.js 24-compatible versions before the **June 2nd, 2026** deadline when GitHub Actions forces Node.js 24.

- `actions/checkout@v4` → `@v6`
- `github/codeql-action/init@v3` → `@v4`
- `github/codeql-action/autobuild@v3` → `@v4` (if present)
- `github/codeql-action/analyze@v3` → `@v4`